### PR TITLE
Force log level to level number for colour determination

### DIFF
--- a/lib/Log/Dispatch/HipChat.pm
+++ b/lib/Log/Dispatch/HipChat.pm
@@ -66,11 +66,12 @@ sub log_message {
     my $http_response;
     my $color = $p{color} || $self->{color};
     if( ! $color and $p{level} ){
-        if( $p{level} >= 4 ){
+        my $level = $self->_level_as_number($p{level});
+        if( $level >= 4 ){
             $color = 'red';
-        }elsif( $p{level} >= 3 ){
+        }elsif( $level >= 3 ){
             $color = 'yellow';
-        }elsif( $p{level} >=1 ){
+        }elsif( $level >=1 ){
             $color = 'green';
         }else{
             $color = 'gray';


### PR DESCRIPTION
Hiya!

I use string log levels at work, and if I didn't provide a colour, the level comparisons were throwing errors. So I used _level_as_number from Log::Dispatch::Output to automatically convert to the level number.

Let me know if there's anything else I should do.

Cheers!
